### PR TITLE
Cleanup context and active record patches

### DIFF
--- a/lib/ar_lazy_preload/active_record/association_relation.rb
+++ b/lib/ar_lazy_preload/active_record/association_relation.rb
@@ -6,19 +6,21 @@ module ArLazyPreload
   module AssociationRelation
     def initialize(*args)
       super(*args)
+      setup_preloading_context unless ArLazyPreload.config.auto_preload?
+    end
 
-      # lazy_preload_values is unnecessary when auto preload enabled
-      return if ArLazyPreload.config.auto_preload?
+    delegate :owner, :reflection, to: :proxy_association
+    delegate :lazy_preload_context, to: :owner
 
-      context = owner.lazy_preload_context
-      return if context.nil?
+    private
 
-      association_tree_builder = AssociationTreeBuilder.new(context.association_tree)
+    def setup_preloading_context
+      return if lazy_preload_context.nil?
+
+      association_tree_builder = AssociationTreeBuilder.new(lazy_preload_context.association_tree)
       subtree = association_tree_builder.subtree_for(reflection.name)
 
       lazy_preload!(subtree)
     end
-
-    delegate :owner, :reflection, to: :proxy_association
   end
 end

--- a/lib/ar_lazy_preload/association_tree_builder.rb
+++ b/lib/ar_lazy_preload/association_tree_builder.rb
@@ -8,9 +8,6 @@ module ArLazyPreload
     attr_reader :association_tree
 
     def initialize(association_tree)
-      # Since `association_tree` can be an array or a single hash
-      # Converting it to an array is easier for processing
-      # like jquery
       @association_tree =
         case association_tree
         when Array
@@ -18,8 +15,7 @@ module ArLazyPreload
         when Hash
           [association_tree]
         else
-          raise NotImplementedError,
-                "unexpected association_tree with class #{association_tree.class}"
+          raise ArgumentError, "unexpected association_tree with class #{association_tree.class}"
         end.select { |node| node.is_a?(Hash) }
     end
 

--- a/lib/ar_lazy_preload/context.rb
+++ b/lib/ar_lazy_preload/context.rb
@@ -1,71 +1,23 @@
 # frozen_string_literal: true
 
-require "ar_lazy_preload/associated_context_builder"
+require "ar_lazy_preload/contexts/base_context"
+require "ar_lazy_preload/contexts/auto_preload_context"
+require "ar_lazy_preload/contexts/lazy_preload_context"
 
 module ArLazyPreload
-  # This class is responsible for holding a connection between a list of ActiveRecord::Base objects
-  # which have been loaded by the same instance of ActiveRecord::Relation. It also contains a tree
-  # of associations, which were requested to be loaded lazily.
-  # Calling #preload_association method will cause loading of ALL associated objects for EACH
-  # ecord when requested association is found in the association tree.
   class Context
     # Initiates lazy preload context for given records
     def self.register(records:, association_tree:)
+      return if records.empty?
+
       if ArLazyPreload.config.auto_preload?
-        # `association_tree` is unnecessary when auto preload is enabled
-        return ArLazyPreload::Context.new(records: records, association_tree: nil)
+        ArLazyPreload::Contexts::AutoPreloadContext.new(records: records)
+      elsif association_tree.any?
+        ArLazyPreload::Contexts::LazyPreloadContext.new(
+          records: records,
+          association_tree: association_tree
+        )
       end
-      return if records.empty? || association_tree.empty? && !ArLazyPreload.config.auto_preload?
-
-      ArLazyPreload::Context.new(records: records, association_tree: association_tree)
-    end
-
-    attr_reader :records, :association_tree
-
-    # :records - array of ActiveRecord instances
-    # :association_tree - list of symbols or hashes representing a tree of preloadable associations
-    def initialize(records:, association_tree:)
-      @records = records
-      @association_tree = association_tree
-
-      @records.each do |record|
-        next if record.nil?
-
-        record.lazy_preload_context = self
-      end
-    end
-
-    # This method checks if the association is present in the association_tree and preloads for all
-    # objects in the context it if needed.
-    def try_preload_lazily(association_name)
-      return unless association_needs_preload?(association_name)
-
-      preloader.preload(records, association_name)
-      AssociatedContextBuilder.prepare(parent_context: self, association_name: association_name)
-    end
-
-    private
-
-    def association_needs_preload?(association_name, node_tree = association_tree)
-      return false if association_loaded?(association_name)
-      return true if ArLazyPreload.config.auto_preload?
-
-      node_tree.any? do |node|
-        case node
-        when Symbol
-          node == association_name
-        when Hash
-          node.key?(association_name)
-        end
-      end
-    end
-
-    def association_loaded?(association_name)
-      records.all? { |record| record.association(association_name).loaded? }
-    end
-
-    def preloader
-      @preloader ||= ActiveRecord::Associations::Preloader.new
     end
   end
 end

--- a/lib/ar_lazy_preload/context.rb
+++ b/lib/ar_lazy_preload/context.rb
@@ -11,9 +11,9 @@ module ArLazyPreload
       return if records.empty?
 
       if ArLazyPreload.config.auto_preload?
-        ArLazyPreload::Contexts::AutoPreloadContext.new(records: records)
+        Contexts::AutoPreloadContext.new(records: records)
       elsif association_tree.any?
-        ArLazyPreload::Contexts::LazyPreloadContext.new(
+        Contexts::LazyPreloadContext.new(
           records: records,
           association_tree: association_tree
         )

--- a/lib/ar_lazy_preload/contexts/auto_preload_context.rb
+++ b/lib/ar_lazy_preload/contexts/auto_preload_context.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module ArLazyPreload
+  module Contexts
+    # This class is responsible for automatic association preloading
+    class AutoPreloadContext < BaseContext
+      protected
+
+      def association_needs_preload?(_association_name)
+        true
+      end
+    end
+  end
+end

--- a/lib/ar_lazy_preload/contexts/base_context.rb
+++ b/lib/ar_lazy_preload/contexts/base_context.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "ar_lazy_preload/associated_context_builder"
+
+module ArLazyPreload
+  module Contexts
+    # This is a base context class, which is responsible for holding a connection between a list of
+    # ActiveRecord::Base objects which have been loaded by the same instance of
+    # ActiveRecord::Relation.
+    class BaseContext
+      attr_reader :records
+
+      # :records - array of ActiveRecord instances
+      def initialize(records:)
+        @records = records.dup
+        @records.compact!
+        @records.each { |record| record.lazy_preload_context = self }
+      end
+
+      # This method checks if the association should be loaded and preloads it for all
+      # objects in the context it if needed.
+      def try_preload_lazily(association_name)
+        return if association_loaded?(association_name) ||
+                  !association_needs_preload?(association_name)
+
+        preloader.preload(records, association_name)
+        AssociatedContextBuilder.prepare(parent_context: self, association_name: association_name)
+      end
+
+      protected
+
+      def association_needs_preload?(_association_name)
+        raise NotImplementedError
+      end
+
+      private
+
+      def association_loaded?(association_name)
+        records.all? { |record| record.association(association_name).loaded? }
+      end
+
+      def preloader
+        @preloader ||= ActiveRecord::Associations::Preloader.new
+      end
+    end
+  end
+end

--- a/lib/ar_lazy_preload/contexts/lazy_preload_context.rb
+++ b/lib/ar_lazy_preload/contexts/lazy_preload_context.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module ArLazyPreload
+  module Contexts
+    # This class is responsible for lazy preloading. It contains a tree of associations, which were
+    # requested to be loaded lazily.
+    class LazyPreloadContext < BaseContext
+      attr_reader :association_tree
+
+      # :records - array of ActiveRecord instances
+      # :association_tree - list of symbols or hashes representing a tree of preloadable
+      # associations
+      def initialize(records:, association_tree:)
+        @association_tree = association_tree
+
+        super(records: records)
+      end
+
+      protected
+
+      def association_needs_preload?(association_name)
+        association_tree.any? do |node|
+          case node
+          when Symbol
+            node == association_name
+          when Hash
+            node.key?(association_name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ar_lazy_preload/associated_context_builder_spec.rb
+++ b/spec/ar_lazy_preload/associated_context_builder_spec.rb
@@ -12,7 +12,7 @@ describe ArLazyPreload::AssociatedContextBuilder do
     expect(user_with_post.posts).not_to be_blank
     expect(user_with_post.account).not_to be_nil
 
-    parent_context = ArLazyPreload::Context.new(
+    parent_context = ArLazyPreload::Context.register(
       records: [user_with_post, user_without_posts],
       association_tree: [{ account: :account_history }]
     )
@@ -26,7 +26,7 @@ describe ArLazyPreload::AssociatedContextBuilder do
   end
 
   it "supports collection associations" do
-    parent_context = ArLazyPreload::Context.new(
+    parent_context = ArLazyPreload::Context.register(
       records: [user_with_post, user_without_posts],
       association_tree: [{ posts: :comments }]
     )
@@ -48,7 +48,7 @@ describe ArLazyPreload::AssociatedContextBuilder do
     records = [vote_for_post, vote_for_comment]
     records.each { |vote| expect(vote.voteable).not_to be_nil }
 
-    parent_context = ArLazyPreload::Context.new(
+    parent_context = ArLazyPreload::Context.register(
       records: records,
       association_tree: [voteable: :user]
     )
@@ -62,7 +62,7 @@ describe ArLazyPreload::AssociatedContextBuilder do
   end
 
   it "skips creating context when child association tree is blank" do
-    parent_context = ArLazyPreload::Context.new(
+    parent_context = ArLazyPreload::Context.register(
       records: [user_with_post, user_without_posts],
       association_tree: [:posts]
     )
@@ -78,7 +78,7 @@ describe ArLazyPreload::AssociatedContextBuilder do
   end
 
   it "skips creating context when list of associated records is blank" do
-    parent_context = ArLazyPreload::Context.new(
+    parent_context = ArLazyPreload::Context.register(
       records: [user_without_posts],
       association_tree: [{ posts: :comments }]
     )

--- a/spec/ar_lazy_preload/association_tree_builder_spec.rb
+++ b/spec/ar_lazy_preload/association_tree_builder_spec.rb
@@ -12,7 +12,7 @@ describe ArLazyPreload::AssociationTreeBuilder do
 
   context "#subtree_for" do
     it "does not support other inputs" do
-      expect { described_class.new(:boom) }.to raise_error(NotImplementedError)
+      expect { described_class.new(:boom) }.to raise_error(ArgumentError)
     end
 
     it "supports symbols" do

--- a/spec/ar_lazy_preload/contexts/lazy_preload_context_spec.rb
+++ b/spec/ar_lazy_preload/contexts/lazy_preload_context_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe ArLazyPreload::Context do
+describe ArLazyPreload::Contexts::LazyPreloadContext do
   let(:user_without_posts) { create(:user) }
   let(:user_with_post) do
     user = create(:user)
@@ -21,14 +21,12 @@ describe ArLazyPreload::Context do
   describe "#initialize" do
     it "assigns context for each record" do
       subject.records.each do |user|
-        next if user.nil?
-
         expect(user.lazy_preload_context).to eq(subject)
       end
     end
 
-    it "does not compact records" do
-      expect(subject.records.size).to eq(3)
+    it "compacts records" do
+      expect(subject.records.size).to eq(2)
     end
   end
 
@@ -36,8 +34,6 @@ describe ArLazyPreload::Context do
     it "does not preload association when it's not in the association_tree" do
       subject.try_preload_lazily(:posts)
       subject.records.each do |user|
-        next if user.nil?
-
         expect(user.posts.loaded?).to be_falsey
       end
     end
@@ -45,8 +41,6 @@ describe ArLazyPreload::Context do
     it "preloads association when it's in the association_tree" do
       subject.try_preload_lazily(:comments)
       subject.records.each do |user|
-        next if user.nil?
-
         expect(user.comments.loaded?).to be_truthy
       end
     end
@@ -54,8 +48,6 @@ describe ArLazyPreload::Context do
     it "creates child preloading context" do
       subject.try_preload_lazily(:comments)
       subject.records.each do |user|
-        next if user.nil?
-
         user.comments.each do |comment|
           expect(comment.lazy_preload_context).not_to be_nil
         end


### PR DESCRIPTION
Changes:

- fix issue coming from two last PRs working together
- split up huge context
- bring back `#association_loaded?` trick
- fix exception class
- use `compact!` to avoid annoing `nil?` checks