### PR TITLE
Improve compatibility with ActiveRecord API for singular associations

### DIFF
--- a/lib/ar_lazy_preload/associated_context_builder.rb
+++ b/lib/ar_lazy_preload/associated_context_builder.rb
@@ -27,9 +27,9 @@ module ArLazyPreload
       associated_records = parent_context.records.flat_map do |record|
         next if record.nil?
 
-        record_association = record.public_send(association_name)
+        record_association = record.association(association_name)
         reflection = reflection_cache[record.class]
-        reflection.collection? ? record_association.target : record_association
+        reflection.collection? ? record_association.target : record_association.reader
       end
 
       Context.register(records: associated_records, association_tree: child_association_tree)


### PR DESCRIPTION
Use relevant ActiveRecord::Associations::Association methods instead of relying on public_send.
This allows application code to override behaviour of model generated association methods, without changing the behaviour of the `model.association().reader` method, when the association is "lazy preloaded".

E.g for a model:
```
class Model < ActiveRecord
  has_one :link

  def link
    puts 'application code'
    super
  end
end
```

calling `Model.lazy_preload(:link).association(:link).reader` would currently print out 'application code'.
This PR makes it so that it doesn't, which is the expected behaviour since that's how ActiveRecord `.preload` behaves.

This incompatibility initially blocked the gem usage in our codebase, but this patch solves the issue for us.