### PR TITLE
Don't do merge if there is nothing to merge

### DIFF
--- a/lib/ar_lazy_preload/active_record/merger.rb
+++ b/lib/ar_lazy_preload/active_record/merger.rb
@@ -8,7 +8,7 @@ module ArLazyPreload
     def merge
       result = super
 
-      if other.lazy_preload_values
+      if other.lazy_preload_values.any?
         if other.klass == relation.klass
           merge_lazy_preloads
         else


### PR DESCRIPTION
Hey Dmitry!

Thanks for this gem :)

I've noticed one minor possible improvement. In `ArLazyPreload::Merger` before choosing a merging strategy, we check if we need to merge something. The thing is: `other.lazy_preload_values` is always `true` when it comes to `if other.lazy_preload_values`. This unexpected merging provoked some errors, pretty similar to one discussed in #30. Of course, this PR is not going to fix the real issue (possible dead associations) but it can prevent people from catching weird errors right after including `ar_lazy_preload` to Gemfile from unexpected places and blaming `ar_lazy_preload` (as it appears in the very top of backtrace). 

PS. I didn't find a way to test this improvement. If you have ideas about it, please, share them and I will add a test here.