### PR TITLE
Use new syntax to avoid 2.7 warning (underlying rails libs still throw)

### DIFF
--- a/lib/ar_lazy_preload/associated_context_builder.rb
+++ b/lib/ar_lazy_preload/associated_context_builder.rb
@@ -8,8 +8,8 @@ module ArLazyPreload
   # the associated records based on the parent association tree.
   class AssociatedContextBuilder
     # Initiates lazy preload context the records loaded lazily
-    def self.prepare(*args)
-      new(*args).perform
+    def self.prepare(**args)
+      new(**args).perform
     end
 
     attr_reader :parent_context, :association_name


### PR DESCRIPTION
Small change to address gem users hitting deprecation warnings when running ruby >2.7.

Please let me know if you'd like me to also go about updating the minor releases on active-support etc that also address this syntax update.


