### PR TITLE
Introduce relation lazy_auto_preload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR [#36](https://github.com/DmitryTsepelev/ar_lazy_preload/pull/36)] Feature preload_associations_lazily, allow turn on automatic preload only for given ActiveRecord::Relation ([@mpospelov][])
+
 ## 0.3.2 (2020-07-21)
 
 - [PR [#33](https://github.com/DmitryTsepelev/ar_lazy_preload/pull/34)] Feature skip_preload, allow turn automatic preload off ([@OuYangJinTing][])

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ users.first.skip_preload.posts # => SELECT * FROM posts WHERE user_id = ?
 
 ### Relation auto preloading
 
-Another alternative for auto preloading is using relation `#lazy_auto_preload` method
+Another alternative for auto preloading is using relation `#preload_associations_lazily` method
 
 ```ruby
-posts = User.lazy_auto_preload.flat_map(&:posts)
+posts = User.preload_associations_lazily.flat_map(&:posts)
 # => SELECT * FROM users LIMIT 10
 # => SELECT * FROM posts WHERE user_id in (...)
 ```

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ If you want to turn automatic preload off for a specific record, you can call `.
 users.first.skip_preload.posts # => SELECT * FROM posts WHERE user_id = ?
 ```
 
+### Relation auto preloading
+
+Another alternative for auto preloading is using relation `#lazy_auto_preload` method
+
+```ruby
+posts = User.lazy_auto_preload.flat_map(&:posts)
+# => SELECT * FROM users LIMIT 10
+# => SELECT * FROM posts WHERE user_id in (...)
+```
+
 ## Installation
 
 Add this line to your application's Gemfile, and you're all set:

--- a/lib/ar_lazy_preload/active_record/base.rb
+++ b/lib/ar_lazy_preload/active_record/base.rb
@@ -5,7 +5,7 @@ module ArLazyPreload
   module Base
     def self.included(base)
       base.class.delegate :lazy_preload, to: :all
-      base.class.delegate :lazy_auto_preload, to: :all
+      base.class.delegate :preload_associations_lazily, to: :all
     end
 
     attr_accessor :lazy_preload_context

--- a/lib/ar_lazy_preload/active_record/base.rb
+++ b/lib/ar_lazy_preload/active_record/base.rb
@@ -5,6 +5,7 @@ module ArLazyPreload
   module Base
     def self.included(base)
       base.class.delegate :lazy_preload, to: :all
+      base.class.delegate :lazy_auto_preload, to: :all
     end
 
     attr_accessor :lazy_preload_context

--- a/lib/ar_lazy_preload/active_record/relation.rb
+++ b/lib/ar_lazy_preload/active_record/relation.rb
@@ -13,10 +13,35 @@ module ArLazyPreload
       if need_context
         Context.register(
           records: ar_lazy_preload_records,
-          association_tree: lazy_preload_values
+          association_tree: lazy_preload_values,
+          auto_preload: lazy_auto_preload_setting
         )
       end
       result
+    end
+
+    # Lazily autoloads all association
+    # example:
+    #
+    #   users = User.lazy_auto_preload
+    #   users.each do |user|
+    #     user.posts.flat_map {|post| post.comments.map(&:id)}
+    #   end
+    #
+    # Same effect can be achieved by User.lazy_preload(posts: :comments)
+    def lazy_auto_preload
+      spawn.lazy_auto_preload!
+    end
+
+    def lazy_auto_preload!
+      self.lazy_auto_preload_setting = true
+      self
+    end
+
+    def lazy_auto_preload_setting
+      return @lazy_auto_preload_setting if defined? @lazy_auto_preload_setting
+
+      @lazy_auto_preload_setting = false
     end
 
     # Specify relationships to be loaded lazily when association is loaded for the first time. For
@@ -56,6 +81,6 @@ module ArLazyPreload
       @records
     end
 
-    attr_writer :lazy_preload_values
+    attr_writer :lazy_preload_values, :lazy_auto_preload_setting
   end
 end

--- a/lib/ar_lazy_preload/associated_context_builder.rb
+++ b/lib/ar_lazy_preload/associated_context_builder.rb
@@ -12,14 +12,13 @@ module ArLazyPreload
       new(*args).perform
     end
 
-    attr_reader :parent_context, :association_name, :auto_preload
+    attr_reader :parent_context, :association_name
 
     # :parent_context - root context
     # :association_name - lazily preloaded association name
-    def initialize(parent_context:, association_name:, auto_preload: false)
+    def initialize(parent_context:, association_name:)
       @parent_context = parent_context
       @association_name = association_name
-      @auto_preload = auto_preload
     end
 
     # Takes all the associated records for the records, attached to the :parent_context and creates
@@ -36,7 +35,7 @@ module ArLazyPreload
       Context.register(
         records: associated_records,
         association_tree: child_association_tree,
-        auto_preload: auto_preload
+        auto_preload: parent_context.auto_preload?
       )
     end
 
@@ -44,7 +43,7 @@ module ArLazyPreload
 
     def child_association_tree
       # `association_tree` is unnecessary when auto preload is enabled
-      return nil if auto_preload
+      return nil if parent_context.auto_preload?
 
       AssociationTreeBuilder.new(parent_context.association_tree).subtree_for(association_name)
     end

--- a/lib/ar_lazy_preload/context.rb
+++ b/lib/ar_lazy_preload/context.rb
@@ -7,10 +7,10 @@ require "ar_lazy_preload/contexts/lazy_preload_context"
 module ArLazyPreload
   class Context
     # Initiates lazy preload context for given records
-    def self.register(records:, association_tree:)
+    def self.register(records:, association_tree:, auto_preload: false)
       return if records.empty?
 
-      if ArLazyPreload.config.auto_preload?
+      if ArLazyPreload.config.auto_preload? || auto_preload
         Contexts::AutoPreloadContext.new(records: records)
       elsif association_tree.any?
         Contexts::LazyPreloadContext.new(

--- a/lib/ar_lazy_preload/contexts/auto_preload_context.rb
+++ b/lib/ar_lazy_preload/contexts/auto_preload_context.rb
@@ -4,13 +4,13 @@ module ArLazyPreload
   module Contexts
     # This class is responsible for automatic association preloading
     class AutoPreloadContext < BaseContext
-      protected
-
-      def association_needs_preload?(_association_name)
+      def auto_preload?
         true
       end
 
-      def auto_preload
+      protected
+
+      def association_needs_preload?(_association_name)
         true
       end
     end

--- a/lib/ar_lazy_preload/contexts/auto_preload_context.rb
+++ b/lib/ar_lazy_preload/contexts/auto_preload_context.rb
@@ -9,6 +9,10 @@ module ArLazyPreload
       def association_needs_preload?(_association_name)
         true
       end
+
+      def auto_preload
+        true
+      end
     end
   end
 end

--- a/lib/ar_lazy_preload/contexts/base_context.rb
+++ b/lib/ar_lazy_preload/contexts/base_context.rb
@@ -34,6 +34,10 @@ module ArLazyPreload
         raise NotImplementedError
       end
 
+      def auto_preload
+        false
+      end
+
       private
 
       def perform_preloading(association_name)
@@ -42,7 +46,8 @@ module ArLazyPreload
 
         AssociatedContextBuilder.prepare(
           parent_context: self,
-          association_name: association_name
+          association_name: association_name,
+          auto_preload: auto_preload
         )
       end
 

--- a/lib/ar_lazy_preload/contexts/base_context.rb
+++ b/lib/ar_lazy_preload/contexts/base_context.rb
@@ -28,15 +28,16 @@ module ArLazyPreload
         perform_preloading(association_name)
       end
 
+      def auto_preload?
+        false
+      end
+
       protected
 
       def association_needs_preload?(_association_name)
         raise NotImplementedError
       end
 
-      def auto_preload
-        false
-      end
 
       private
 
@@ -46,8 +47,7 @@ module ArLazyPreload
 
         AssociatedContextBuilder.prepare(
           parent_context: self,
-          association_name: association_name,
-          auto_preload: auto_preload
+          association_name: association_name
         )
       end
 

--- a/spec/ar_lazy_preload/preload_associations_lazily_spec.rb
+++ b/spec/ar_lazy_preload/preload_associations_lazily_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "ActiveRecord::Relation.lazy_auto_preload" do
+describe "ActiveRecord::Relation.preload_associations_lazily" do
   let!(:user1) { create(:user) }
   let!(:user2) { create(:user) }
 
@@ -11,7 +11,7 @@ describe "ActiveRecord::Relation.lazy_auto_preload" do
   let!(:comment1) { create(:comment, user: user2, post: post) }
 
   describe "auto preloading" do
-    subject { Comment.lazy_auto_preload }
+    subject { Comment.preload_associations_lazily }
 
     # SELECT "comments".* FROM "comments"
     # SELECT "users".* FROM "users" WHERE "users"."id" IN (...)

--- a/spec/ar_lazy_preload/relation_lazy_auto_preload_spec.rb
+++ b/spec/ar_lazy_preload/relation_lazy_auto_preload_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "ActiveRecord::Relation.lazy_auto_preload" do
+  let!(:user1) { create(:user) }
+  let!(:user2) { create(:user) }
+
+  let!(:post) { create(:post, user: user1) }
+  let!(:comment1) { create(:comment, user: user1, post: post) }
+  let!(:comment1) { create(:comment, user: user2, post: post) }
+
+  describe "auto preloading" do
+    subject { Comment.lazy_auto_preload }
+
+    # SELECT "comments".* FROM "comments"
+    # SELECT "users".* FROM "users" WHERE "users"."id" IN (...)
+    it "loads association automatically" do
+      expect { subject.each { |comment| comment.user&.id } }.to make_database_queries(count: 2)
+    end
+  end
+end


### PR DESCRIPTION
Hi there! Thanks for great gem 🙏💎

This is a feature request with PR. 

### Motivation

I would like to use your library without setting `ArLazyPreload.config.auto_preload = true`, as on our project there some guys who are not so lazy as me. So to find something in the middle I would like to specify that certain relation can preload association but I'm still too lazy to list preloaded associations 😔 

### Implementation

So in order to address this issue, I added `ArLazyPreload::Reloaded#lazy_auto_preload` which works in the same way as `ArLazyPreload.config.auto_preload` but in the scope of one relation.