### PR TITLE
Fix error when association relation spawned from relation with preload_associations_lazily called

### DIFF
--- a/lib/ar_lazy_preload/active_record/association_relation.rb
+++ b/lib/ar_lazy_preload/active_record/association_relation.rb
@@ -16,6 +16,7 @@ module ArLazyPreload
 
     def setup_preloading_context
       return if lazy_preload_context.nil?
+      return if lazy_preload_context.association_tree.nil?
 
       association_tree_builder = AssociationTreeBuilder.new(lazy_preload_context.association_tree)
       subtree = association_tree_builder.subtree_for(reflection.name)

--- a/lib/ar_lazy_preload/contexts/base_context.rb
+++ b/lib/ar_lazy_preload/contexts/base_context.rb
@@ -19,6 +19,9 @@ module ArLazyPreload
         @records.each { |record| record.lazy_preload_context = self }
       end
 
+      # @api
+      def association_tree; nil; end
+
       # This method checks if the association should be loaded and preloads it for all
       # objects in the context it if needed.
       def try_preload_lazily(association_name)


### PR DESCRIPTION
I got this error during development:
`NoMethodError: undefined method `association_tree' for #<ArLazyPreload::Contexts::AutoPreloadContext:0x00007fbb492fbd20>`

So I created this PR


