### PR TITLE
Fixes for handling STI associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR [#39](https://github.com/DmitryTsepelev/ar_lazy_preload/pull/39)] Fix error when trying to preload non-existent association on STI model ([@konalegi][])
+
 ## 0.5.1 (2020-08-28)
 
 - [PR [#38](https://github.com/DmitryTsepelev/ar_lazy_preload/pull/38)] Fix error when association relation spawned from relation with preload_associations_lazily called ([@PikachuEXE][])

--- a/lib/ar_lazy_preload/associated_context_builder.rb
+++ b/lib/ar_lazy_preload/associated_context_builder.rb
@@ -28,8 +28,10 @@ module ArLazyPreload
       associated_records = parent_context.records.flat_map do |record|
         next if record.nil?
 
-        record_association = record.association(association_name)
         reflection = reflection_cache[record.class]
+        next if reflection.nil?
+
+        record_association = record.association(association_name)
         reflection.collection? ? record_association.target : record_association.reader
       end
 

--- a/spec/ar_lazy_preload/associated_context_builder_spec.rb
+++ b/spec/ar_lazy_preload/associated_context_builder_spec.rb
@@ -61,6 +61,27 @@ describe ArLazyPreload::AssociatedContextBuilder do
     [post, comment].each { |voteable| expect(voteable.lazy_preload_context).not_to be_nil }
   end
 
+  it "supports STI associations" do
+    user = create(:user)
+    post1 = create(:post, user: user)
+    post2 = create(:private_post, user: user)
+
+    expect(post2.level).not_to be_nil
+    records = [post1, post2]
+
+    parent_context = ArLazyPreload::Context.register(
+      records: records,
+      association_tree: [posts: :level]
+    )
+
+    described_class.new(
+      parent_context: parent_context,
+      association_name: :level
+    ).perform
+
+    [post2, post1].each { |post| expect(post.lazy_preload_context).not_to be_nil }
+  end
+
   it "skips creating context when child association tree is blank" do
     parent_context = ArLazyPreload::Context.register(
       records: [user_with_post, user_without_posts],

--- a/spec/helpers/factories.rb
+++ b/spec/helpers/factories.rb
@@ -27,6 +27,22 @@ FactoryBot.define do
     end
   end
 
+  factory :private_post do
+    level
+
+    trait :level_two do
+      association :level, :level_two
+    end
+  end
+
+  factory :level do
+    name { "Level one" }
+
+    trait :level_two do
+      name { "Level two" }
+    end
+  end
+
   factory :comment do
     user
   end

--- a/spec/helpers/models.rb
+++ b/spec/helpers/models.rb
@@ -19,6 +19,14 @@ class Post < ActiveRecord::Base
   has_many :votes, as: :voteable
 end
 
+class PrivatePost < Post
+  belongs_to :level
+end
+
+class Level < ActiveRecord::Base
+  has_many :private_posts
+end
+
 class Comment < ActiveRecord::Base
   belongs_to :post
   belongs_to :user

--- a/spec/helpers/schema.rb
+++ b/spec/helpers/schema.rb
@@ -9,6 +9,15 @@ ActiveRecord::Schema.define do
 
   create_table :posts do |t|
     t.references :user, foreign_key: true
+    t.string :type
+    t.references :level, foreign_key: true
+
+    t.timestamps null: false
+  end
+
+  create_table :levels do |t|
+    t.references :post, foreign_key: true
+    t.string :name
 
     t.timestamps null: false
   end


### PR DESCRIPTION
Hey! Thanks for the great gem!

I want to purpose fixes for situations when we are trying to preload associations for the STI models.
Example:
```
class User < ActiveRecord::Base
  has_many :posts
end

class Post < ActiveRecord::Base
  belongs_to :user
end

class PrivatePost < Post
  belongs_to :level
end

class Level < ActiveRecord::Base
  has_many :private_posts
end

=> User.lazy_preload(posts: [:level])
```
In this case, the library couldn't load the levels for the posts, because of not all posts implements `:level` association.
Not sure that implementation is correct, but it works for me and my project.
Thanks!
