### PR TITLE
Remove leftovers after STI association error is fixed

### DIFF
--- a/spec/helpers/schema.rb
+++ b/spec/helpers/schema.rb
@@ -16,7 +16,6 @@ ActiveRecord::Schema.define do
   end
 
   create_table :levels do |t|
-    t.references :post, foreign_key: true
     t.string :name
 
     t.timestamps null: false


### PR DESCRIPTION
After I've merged the fix for the [STI association error](https://github.com/DmitryTsepelev/ar_lazy_preload/pull/39), I've added an unneeded reference in the schema. In this PR I'm removing it.