### PR TITLE
Add failing test case for `preload_associations_lazily` for association defined with scope

### DIFF
--- a/spec/ar_lazy_preload/preload_associations_lazily_spec.rb
+++ b/spec/ar_lazy_preload/preload_associations_lazily_spec.rb
@@ -27,5 +27,15 @@ describe "ActiveRecord::Relation.preload_associations_lazily" do
         end
       end.to_not raise_error
     end
+
+    # SELECT "users".* FROM "users"
+    # SELECT "comments".* FROM "comments" WHERE "comments"."user_id" IN (...) AND "comments"."parent_comment_id" IS NULL
+    it "does not load association defined with scope" do
+      expect do
+        subject.flat_map do |u|
+          u.thread_comments.size
+        end
+      end.to make_database_queries(count: 2)
+    end
   end
 end

--- a/spec/helpers/models.rb
+++ b/spec/helpers/models.rb
@@ -7,6 +7,7 @@ class User < ActiveRecord::Base
   has_many :posts
   has_many :comments
   has_many :comments_on_posts, through: :posts, source: :comments
+  has_many :thread_comments, -> { threads }, class_name: "Comment"
 
   def vote_for(voteable)
     voteable.votes.create(user: self)


### PR DESCRIPTION
Similar to #40 
This is a bug I have no idea how to solve