### PR TITLE
Add Ruby 3.0 and 3.1 to CI

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7]
+        ruby: [2.6, 2.7, '3.0', 3.1]
 
         gemfile: [
           "gemfiles/rails_5_2.gemfile",
@@ -39,6 +39,12 @@ jobs:
         exclude:
           - ruby: 2.6
             gemfile: gemfiles/rails_7_0.gemfile
+          - ruby: '3.0'
+            gemfile: gemfiles/rails_5_2.gemfile
+          - ruby: 3.1
+            gemfile: gemfiles/rails_5_2.gemfile
+          - ruby: 3.1
+            gemfile: gemfiles/rails_6_0.gemfile
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR adds Ruby 3.0 and 3.1 to the rspec.yaml file, with appropriate exclusions.