### PR TITLE
Add another gotcha about preloading ActiveStorage variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ posts = User.preload_associations_lazily.flat_map(&:posts)
 
 2. When `#size` is called on association (e.g., `User.lazy_preload(:posts).map { |u| u.posts.size }`), lazy preloading won't happen, because `#size` method performs `SELECT COUNT()` database request instead of loading the association when association haven't been loaded yet ([here](https://github.com/DmitryTsepelev/ar_lazy_preload/pull/42) is the issue, and [here](https://blazarblogs.wordpress.com/2019/07/27/activerecord-size-vs-count-vs-length/) is the explanation article about `size`, `length` and `count`).
 
+3. Lazy preloading for **ActiveStorage** variants is not working automatically because of the way how it is implemented ([here](https://github.com/DmitryTsepelev/ar_lazy_preload/pull/70) is the issue). You can preload them manually by calling `#with_all_variant_records`/`#with_attached_#{attachment_name}` on association. Example: `User.with_attached_avatar.first(10).map { |u| u.avatar.variant(:small).processed.url }`
 
 ## Installation
 


### PR DESCRIPTION
The way how [ActiveStorage::VariantWithRecord#record](https://github.com/rails/rails/blob/84f773f9d16b21c74b60160b1aa9cc48f2fd839b/activestorage/app/models/active_storage/variant_with_record.rb#L66) is implemented breaks auto-preloading Active Storage variants:
```ruby
  @record ||= if blob.variant_records.loaded? # <--- Here is the issue, association is not preloaded yet - so `find_by` is used
    blob.variant_records.find { |v| v.variation_digest == variation.digest }
  else
    blob.variant_records.find_by(variation_digest: variation.digest)
  end
```

To prevent `n+1` you still need to use built-in Active Storage methods for preloading associations.

Examples:
```ruby
User.with_attached_avatar.find(100).map { _1.avatar.variant(:small).processed.url }
```
or
```ruby
message.images.with_all_variant_records.map do |file|
  file.representation(resize_to_limit: [100, 100]).processed.url
end
```
