### PR TITLE
Fix extra queries for singular through-associations with STI

### DIFF
--- a/lib/ar_lazy_preload/associated_context_builder.rb
+++ b/lib/ar_lazy_preload/associated_context_builder.rb
@@ -32,7 +32,7 @@ module ArLazyPreload
         next if reflection.nil?
 
         record_association = record.association(association_name)
-        reflection.collection? ? record_association.target : record_association.reader
+        record_association.target
       end
 
       Context.register(

--- a/lib/ar_lazy_preload/contexts/base_context.rb
+++ b/lib/ar_lazy_preload/contexts/base_context.rb
@@ -90,7 +90,7 @@ module ArLazyPreload
       def collect_intermediate_records(klass_records, reflection)
         klass_records.flat_map do |record|
           record_association = record.association(reflection.name)
-          reflection.collection? ? record_association.target : record_association.reader
+          record_association.target
         end.compact
       end
 

--- a/spec/ar_lazy_preload/preload_associations_lazily_spec.rb
+++ b/spec/ar_lazy_preload/preload_associations_lazily_spec.rb
@@ -144,4 +144,32 @@ describe "ActiveRecord::Relation.preload_associations_lazily" do
       end.to_not raise_error
     end
   end
+
+  describe "has_one through with STI" do
+    let!(:candidate1) { create(:candidate, name: "Alice") }
+    let!(:candidate2) { create(:candidate, name: "Bob") }
+    let!(:application1) { create(:application, candidate: candidate1) }
+    let!(:application2) { create(:application, candidate: candidate2) }
+    let!(:assignment1) { create(:assignment, application: application1) }
+    let!(:assignment2) { create(:assignment, application: application2) }
+
+    # When STI is involved, the preloader uses a LEFT OUTER JOIN strategy
+    # which does not mark the intermediate belongs_to as loaded on each record.
+    # Previously, collect_intermediate_records called .reader on the unloaded
+    # association proxy, triggering an extra SELECT per record.
+    it "does not trigger extra queries for intermediate association" do
+      assignments = Assignment.preload_associations_lazily.to_a
+
+      expect do
+        assignments.each { |a| a.candidate }
+      end.to make_database_queries(count: 1)
+    end
+
+    it "sets lazy_preload_context on the through-association result" do
+      assignments = Assignment.preload_associations_lazily.to_a
+      assignments.each do |a|
+        expect(a.candidate.lazy_preload_context).not_to be_nil
+      end
+    end
+  end
 end

--- a/spec/helpers/factories.rb
+++ b/spec/helpers/factories.rb
@@ -56,4 +56,16 @@ FactoryBot.define do
     user
     role { :owner }
   end
+
+  factory :candidate do
+    name { "Test Candidate" }
+  end
+
+  factory :application do
+    candidate
+  end
+
+  factory :assignment do
+    application
+  end
 end

--- a/spec/helpers/models.rb
+++ b/spec/helpers/models.rb
@@ -73,3 +73,18 @@ class ClubMember < ActiveRecord::Base
 
   enum :role, { owner: 0, contributor: 1 }
 end
+
+class Person < ActiveRecord::Base
+end
+
+class Candidate < Person
+end
+
+class Application < ActiveRecord::Base
+  belongs_to :candidate, class_name: "Candidate"
+end
+
+class Assignment < ActiveRecord::Base
+  belongs_to :application
+  has_one :candidate, through: :application
+end

--- a/spec/helpers/schema.rb
+++ b/spec/helpers/schema.rb
@@ -73,6 +73,26 @@ ActiveRecord::Schema.define do
     t.timestamps null: false
   end
 
+  create_table :people do |t|
+    t.string :type, null: false
+    t.string :name
+
+    t.timestamps null: false
+  end
+
+  create_table :applications do |t|
+    t.references :candidate, null: false, foreign_key: { to_table: :people }
+    t.string :status, default: "pending"
+
+    t.timestamps null: false
+  end
+
+  create_table :assignments do |t|
+    t.references :application, null: false, foreign_key: true
+
+    t.timestamps null: false
+  end
+
   add_foreign_key :posts, :users
   add_foreign_key :posts, :levels
   add_foreign_key :comments, :posts


### PR DESCRIPTION
## Summary

- `collect_intermediate_records` (base_context.rb:93) and `AssociatedContextBuilder#perform` (associated_context_builder.rb:35) used `.reader` for singular associations, which calls `load_target` unconditionally
- With STI, the preloader uses a `LEFT OUTER JOIN` strategy that does **not** mark the intermediate `belongs_to` as loaded on each record
- `.reader` then fires an extra `SELECT` per record to load the already-populated association
- Fix: use `.target` instead, which returns the in-memory value without hitting the database

Fixes #90

## Reproduction

`Assignment` has `has_one :candidate, through: :application`, where `Candidate` is an STI subclass of `Person`:

```ruby
assignments = Assignment.preload_associations_lazily.to_a
assignments.each { |a| a.candidate }
```

**Before (2.1.1):** 1 + N queries (1 JOIN preload + 1 extra `SELECT applications.*` per record)
**After:** 1 query (just the JOIN preload)

## Test plan

- [x] Added test for `has_one through` with STI models (`Assignment -> Application -> Candidate < Person`)
- [x] Full test suite passes (109 examples, 0 failures)