### PR TITLE
Do not reset loaded relations when using `preload_associations_lazily`

### DIFF
--- a/lib/ar_lazy_preload/active_record/relation.rb
+++ b/lib/ar_lazy_preload/active_record/relation.rb
@@ -44,7 +44,7 @@ module ArLazyPreload
     #
     # Same effect can be achieved by User.lazy_preload(posts: :comments)
     def preload_associations_lazily
-      spawn.tap { |relation| relation.preloads_associations_lazily = true }
+      tap { |relation| relation.preloads_associations_lazily = true }
     end
 
     # Specify relationships to be loaded lazily when association is loaded for the first time. For

--- a/spec/ar_lazy_preload/preload_associations_lazily_spec.rb
+++ b/spec/ar_lazy_preload/preload_associations_lazily_spec.rb
@@ -143,6 +143,14 @@ describe "ActiveRecord::Relation.preload_associations_lazily" do
         end
       end.to_not raise_error
     end
+
+    it "does not reset loaded relations" do
+      posts = Post.all.load
+      posts = posts.preload_associations_lazily
+      expect do
+        posts.size
+      end.to_not make_database_queries
+    end
   end
 
   describe "has_one through with STI" do


### PR DESCRIPTION
Fixes #87.